### PR TITLE
2025-01-03

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-01-01T10:12:13.867363200Z">
+        <DropdownSelection timestamp="2025-01-03T07:39:40.097573500Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=R3CR90NVMDW" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
-
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/logcat/MainActivity.java
+++ b/app/src/main/java/com/example/logcat/MainActivity.java
@@ -1,17 +1,65 @@
 package com.example.logcat;
 
+import android.Manifest;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
 public class MainActivity extends AppCompatActivity {
+
+    private static final int REQUEST_CODE_READ_MEDIA_IMAGES = 100;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        // 서비스 시작 (앱이 실행될 때 자동 시작)
+        // 권한 요청
+        checkAndRequestPermissions();
+    }
+
+    private void checkAndRequestPermissions() {
+        // READ_MEDIA_IMAGES 권한 확인
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_MEDIA_IMAGES)
+                != PackageManager.PERMISSION_GRANTED) {
+            // 권한 요청
+            ActivityCompat.requestPermissions(this,
+                    new String[]{Manifest.permission.READ_MEDIA_IMAGES}, REQUEST_CODE_READ_MEDIA_IMAGES);
+        } else {
+            Log.d("MainActivity", "READ_MEDIA_IMAGES permission granted.");
+            // 권한이 이미 허용된 경우 추가 작업 수행
+            startMonitoringService();
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        if (requestCode == REQUEST_CODE_READ_MEDIA_IMAGES) {
+            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                Log.d("MainActivity", "READ_MEDIA_IMAGES permission granted by user.");
+                // 권한이 허용되었을 때 수행할 작업
+                startMonitoringService();
+            } else {
+                Log.d("MainActivity", "READ_MEDIA_IMAGES permission denied by user.");
+                // 권한이 거부되었을 때 처리할 작업
+                Toast.makeText(this, "Permission is required to monitor media changes.", Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
+
+    private void startMonitoringService() {
         Intent serviceIntent = new Intent(this, MonitoringService.class);
-        startForegroundService(serviceIntent);
+        startService(serviceIntent);
+        Log.d("MainActivity", "MonitoringService started.");
     }
 }


### PR DESCRIPTION
Gallery 조작 탐지

1. 저장된 사진의 파일명 혹은 시간 조작시 로그 작성 구현
2. 정확한 파일명을 확인하기 위해서 권한의 READ_MEDIA_IMAGES 추가
    해당 권한은 run-time으로 user에게 권한 승인 요청을 받아야함
    - 거절할 것을 우려하여 해당 권한을 사용하지 않을시 내부 저장소의 식별용 ID는 남길 수 있지만 이는 포렌식 과정에서 추가적인 노동력을 소요할 것으로 생각됨

개선 사항
1. 사진을 새로 찍거나 사진을 삭제하는 경우에도 event가 탐지되어 로그를 남김
이를 개선하기 위한 로직 구현은 가능하지만 어떻게 할지 논의 필요